### PR TITLE
Fix chimp timeout settings and reformat config

### DIFF
--- a/chimp.js
+++ b/chimp.js
@@ -8,28 +8,28 @@ module.exports = {
 
   webdriverio: {
     baseUrl: process.env.BASE_URL || 'http://localhost:3000',
-    desiredCapabilities: {
-    bail: 1,
-    browserName: "chrome",
-    javascriptEnabled: true,
-    maxInstances: 1,
-    loggingPrefs: {
-      browser: "ALL",
-      driver: "ALL",
-      server: "ALL"
-    },
-    chromeOptions: {
-      args: [
-         process.env.HEADLESS ? "--headless" : "--start-maximized",
-         "--disable-gpu",
-         "--window-size=1920,1080",
-         "--no-sandbox",
-         "--disable-extensions"
-      ]
-    },
     waitforTimeout: 5000,
-    waitforInterval: 2000
-   }
+    waitforInterval: 2000,
+    bail: 1,
+    desiredCapabilities: {
+      browserName: "chrome",
+      javascriptEnabled: true,
+      maxInstances: 1,
+      loggingPrefs: {
+        browser: "ALL",
+        driver: "ALL",
+        server: "ALL"
+      },
+      chromeOptions: {
+        args: [
+          process.env.HEADLESS ? "--headless" : "--start-maximized",
+          "--disable-gpu",
+          "--window-size=1920,1080",
+          "--no-sandbox",
+          "--disable-extensions"
+        ]
+      },
+    }
   },
   seleniumStandaloneOptions: {
     drivers: {


### PR DESCRIPTION
The timeout settings in the Chimp config were in the wrong place so default timeouts were being used instead leading to flaky tests. 

You can test by changing the defaults to something small (100) and running the tests. 