### PR TITLE
Wait for new page before continuing

### DIFF
--- a/chimp.js
+++ b/chimp.js
@@ -9,7 +9,7 @@ module.exports = {
   webdriverio: {
     baseUrl: process.env.BASE_URL || 'http://localhost:3000',
     waitforTimeout: 5000,
-    waitforInterval: 2000,
+    waitforInterval: 200,
     bail: 1,
     desiredCapabilities: {
       browserName: "chrome",

--- a/tests/pages/design-questionnaire-navigation.page.js
+++ b/tests/pages/design-questionnaire-navigation.page.js
@@ -1,0 +1,6 @@
+class DesignQuestionnaireNavigation {
+  static page(number) {
+    return `li[class^='PageNav__StyledPageItem']:nth-child(${number})`;
+  }
+}
+module.exports = DesignQuestionnaireNavigation;

--- a/tests/spec/smoketest-eq-services-spec.js
+++ b/tests/spec/smoketest-eq-services-spec.js
@@ -6,6 +6,7 @@ chai.should();
 
 const AuthorHelpers = require('../author-helpers');
 const DesignQuestionnairePage = require('../pages/design-questionnaire.page');
+const DesignQuestionnaireNavigationPage = require('../pages/design-questionnaire-navigation.page');
 
 describe('eQ Services Smoke Test', () => {
   it('should update navigation title when section title changed', () =>
@@ -23,7 +24,7 @@ describe('eQ Services Smoke Test', () => {
 
     // // Adds second Question
       .click(DesignQuestionnairePage.clickAddPage())
-      .waitForExist(DesignQuestionnairePage.setQuestionTitle())
+      .waitForExist(DesignQuestionnaireNavigationPage.page(2))
       .setValue(DesignQuestionnairePage.setQuestionTitle(), 'Test Question 2')
       .click(DesignQuestionnairePage.clickAddAnswer())
       .click(DesignQuestionnairePage.selectTextFieldAnswer())


### PR DESCRIPTION
The existing code does not wait for the new page to be open before adding new questions.
As the identifier it was looking for was on both the old and new page.

This change makes the test wait for the page to be listed in the navigation.

## How to review
Keep running it to see if you can make it intermittently fail