### PR TITLE
Add waits for the author animations to finish

### DIFF
--- a/tests/spec/smoketest-eq-services-spec.js
+++ b/tests/spec/smoketest-eq-services-spec.js
@@ -21,7 +21,9 @@ describe('eQ Services Smoke Test', () => {
     // Adds first question
     await browser.setValue(DesignQuestionnairePage.setQuestionTitle(), 'Test Question 1')
       .click(DesignQuestionnairePage.clickAddAnswer())
+      .pause(500)
       .click(DesignQuestionnairePage.selectTextFieldAnswer())
+      .pause(500)
       .waitForExist(DesignQuestionnairePage.setAnswerTitle())
       .setValue(DesignQuestionnairePage.setAnswerTitle(), 'Test Answer 1');
 
@@ -31,7 +33,9 @@ describe('eQ Services Smoke Test', () => {
       .waitForExist(DesignQuestionnaireNavigationPage.page(2))
       .setValue(DesignQuestionnairePage.setQuestionTitle(), 'Test Question 2')
       .click(DesignQuestionnairePage.clickAddAnswer())
+      .pause(500)
       .click(DesignQuestionnairePage.selectTextFieldAnswer())
+      .pause(500)
       .waitForExist(DesignQuestionnairePage.setAnswerTitle())
       .setValue(DesignQuestionnairePage.setAnswerTitle(), 'Test Answer 2');
 


### PR DESCRIPTION
The tests were trying to click on links before the animations had finished.
This was exaggerated on Concourse as it is probably not as fast as rendering the animations.

This has been run continuously (1 minute intervals) without failing on Concourse
http://concourse.dev.eq.ons.digital/teams/main/pipelines/smoke-test