### PR TITLE
Fix occasional cypress bug

### DIFF
--- a/author-override.yml
+++ b/author-override.yml
@@ -1,4 +1,4 @@
-version: '1'
+version: '3'
 
 services:
 

--- a/author-override.yml
+++ b/author-override.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '1'
 
 services:
 

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
-    "viewportHeight": 660,
-    "viewportWidth": 1280,
-    "chromeWebSecurity": false,
-    "projectId": "2yme3a"
+  "viewportHeight": 660,
+  "viewportWidth": 1280,
+  "chromeWebSecurity": false,
+  "projectId": "2yme3a",
+  "modifyObstructiveCode": false
 }

--- a/scripts/eq-compose.sh
+++ b/scripts/eq-compose.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl https://raw.githubusercontent.com/ONSdigital/eq-compose/master/eq.yml > docker-compose.yml
+curl https://raw.githubusercontent.com/ONSdigital/eq-compose/master/docker-compose.yml > docker-compose.yml
 
 docker-compose -f docker-compose.yml -f author-override.yml up &
 pid=$!


### PR DESCRIPTION
While testing cypress against our staging environment we continued to get an error where we were getting a mangled regex expression console error reported. 
After investigating it seemed possible that this was due to the modifyObstructiveCode that cypress run at the beginning of it's tests.

This PR aims to remove that functionality and hopefully return cypress to a working state.