### PR TITLE
Remove check for section title on block.

### DIFF
--- a/cypress/integration/smoketest_spec.js
+++ b/cypress/integration/smoketest_spec.js
@@ -57,8 +57,6 @@ describe("eq-services", () => {
 
         it("Contains all the necessary fields in the correct formatting", () => {
 
-            cy.get(testId(`block-title`, "qa")).should("contain", "This is Section 1");
-
             cy.get(testId(`question-title`, "qa")).should("contain", "This is Page 1");
 
             cy.get(testId(`input-text`, "qa")).should("exist");


### PR DESCRIPTION
### Description

Section titles were previously displayed on blocks. But a recent change to publisher requirements means that section titles are no longer displayed. This change removes the check from the smoke test.

### How to test
Smoke test should not fail when previewing a questionnaire.