### PR TITLE
Changed the data test attribute from data-testId to data-test

### DIFF
--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -15,7 +15,7 @@ export const addQuestionnaire = title => {
 };
 
 export function setQuestionnaireSettings(name) {
-    cy.get(`[data-testid="questionnaire-settings-modal"]`).within(() => {
+    cy.get(testId("questionnaire-settings-modal")).within(() => {
         cy
             .get(testId("txt-questionnaire-title"))
             .clear()


### PR DESCRIPTION
The smoke tests are currently broken as a attribute has changed names on the front end from [data-testId] to [data-test] this PR changes the smoke tests to recognise this new attribute name.

Tests should pass.