### PR TITLE
Failing to update questionnaire properties

### DIFF
--- a/cypress/integration/smoketest_spec.js
+++ b/cypress/integration/smoketest_spec.js
@@ -1,66 +1,100 @@
 import {
-    addQuestionnaire,
-    typeIntoDraftEditor,
-    testId,
-    signIn
+  addQuestionnaire,
+  typeIntoDraftEditor,
+  testId,
+  signIn
 } from "../utils";
 
 describe("eq-services", () => {
+  let token;
 
-    describe("Questionnaire creation", () => {
-        it("Can create a questionnaire", () => {
-            cy.visit("/");
-            signIn();
-            addQuestionnaire("My Questionnaire Title");
-        });
+  function restoreLocalStorageAuth() {
+    console.log("restore", token);
+    if (token) {
+      localStorage.setItem("accessToken", token);
+    }
+  }
 
-        it("Can name the Page and Section", () => {
+  function cacheLocalStorageAuth() {
+    const windowToken = localStorage.getItem("accessToken");
+    console.log("cache", token);
+    if (windowToken) {
+      token = windowToken;
+    }
+  }
 
-            cy.get(testId("page-item")).click();
-            typeIntoDraftEditor(
-                testId("txt-question-title", "testid"),
-                "This is Page 1"
-            );
-            cy.get(testId("side-nav")).should("contain", "This is Page 1");
+  beforeEach(() => {
+    cy.log("before Each", token);
+    if (token) {
+      localStorage.setItem("accessToken", token);
+    }
+    cy.wait(1000);
+  });
+  afterEach(() => {
+    const windowToken = localStorage.getItem("accessToken");
+    cy.log("after each", token);
+    if (windowToken) {
+      token = windowToken;
+    }
+  });
 
-            cy.get(testId("nav-section-link")).click();
+  Cypress.on("window:before:load", restoreLocalStorageAuth);
+  Cypress.on("window:before:unload", cacheLocalStorageAuth);
 
-            typeIntoDraftEditor(
-                testId("txt-section-title", "testid"),
-                "This is Section 1"
-            );
-
-            cy.get(testId("side-nav")).should("contain", "This is Section 1");
-        });
-
-        it("Can add a answer", () => {
-            cy.get(testId("page-item")).click();
-
-            cy.get(testId("btn-add-answer")).click();
-
-            cy.get(testId(`btn-answer-type-currency`)).click();
-
-            cy.get("[data-test='txt-answer-label']").type("This is an answer label");
-
-            cy.get("[data-test='txt-answer-description']").type("This is an answer description");
-        });
+  describe("Questionnaire creation", () => {
+    it("Can create a questionnaire", () => {
+      cy.visit("/");
+      signIn();
+      addQuestionnaire("My Questionnaire Title");
     });
 
-    describe("Runner previewing", () => {
+    it("Can name the Page and Section", () => {
+      cy.get(testId("page-item")).click();
+      typeIntoDraftEditor(
+        testId("txt-question-title", "testid"),
+        "This is Page 1"
+      );
+      cy.get(testId("side-nav")).should("contain", "This is Page 1");
 
-        it("can switch to a Runner preview.", () => {
-            cy
-                .get(`[data-test="btn-preview"]`)
-                .invoke("removeAttr", "target")
-                .click();
-        });
+      cy.get(testId("nav-section-link")).click();
 
-        it("Contains all the necessary fields in the correct formatting", () => {
+      typeIntoDraftEditor(
+        testId("txt-section-title", "testid"),
+        "This is Section 1"
+      );
 
-            cy.get(testId(`question-title`, "qa")).should("contain", "This is Page 1");
-
-            cy.get(testId(`input-number`, "qa")).should("exist");
-        });
+      cy.get(testId("side-nav")).should("contain", "This is Section 1");
     });
 
+    it("Can add a answer", () => {
+      cy.get(testId("page-item")).click();
+
+      cy.get(testId("btn-add-answer")).click();
+
+      cy.get(testId(`btn-answer-type-currency`)).click();
+
+      cy.get("[data-test='txt-answer-label']").type("This is an answer label");
+
+      cy.get("[data-test='txt-answer-description']").type(
+        "This is an answer description"
+      );
+    });
+  });
+
+  describe("Runner previewing", () => {
+    it("can switch to a Runner preview.", () => {
+      cy.get(`[data-test="btn-preview"]`)
+        .invoke("removeAttr", "target")
+        .click();
+    });
+
+    it("Contains all the necessary fields in the correct formatting", () => {
+      cy.get(testId(`question-title`, "qa")).should(
+        "contain",
+        "This is Page 1"
+      );
+
+      cy.get(testId(`input-number`, "qa")).should("exist");
+    });
+  });
 });


### PR DESCRIPTION
They are failing because for some reason cypress is clearing out the
localStorage so the first couple of graphql calls fail - it then
succeeds.

Cypress is supposed to fully clear out localStorage between tests (`it`)
but seems to do it badly. They want to give users control over this but
that is coming later. https://github.com/cypress-io/cypress/issues/686

~~To resolve this issue for the moment - saving logging in over and over
is to put all the work into 2 tests, one for author side and one for
runner.~~
To resolve this issue for the moment is to cache the access token and
re-add it at the start of each test.