### PR TITLE
Revert selector back from input-number to input-text.

### DIFF
--- a/cypress/integration/smoketest_spec.js
+++ b/cypress/integration/smoketest_spec.js
@@ -57,7 +57,7 @@ describe("eq-services", () => {
         "This is Page 1"
       );
 
-      cy.get(testId(`input-number`, "qa")).should("exist");
+      cy.get(testId(`input-text`, "qa")).should("exist");
     });
   });
 });


### PR DESCRIPTION
### Description
This change reverts a change that was made previously to select elements with a test Id of input-number back to input-text.

The change is required to resolve the broken smoke tests.

### How to review
All tests and checks should pass.